### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Dockerfile.jenkins-arm
+++ b/Dockerfile.jenkins-arm
@@ -1,0 +1,10 @@
+FROM phenomique/raspberry-sane-git
+RUN apt-get update \
+    && apt-get install -y python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip3 install tox
+
+# This is a bit hackish but necessary because Jenkins runs container with the
+# UID of the jenkins user on the node and pytest wan't to find the home
+# directory of the current user.
+RUN useradd --uid 1001 --create-home jenkins

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,17 @@
+pipeline {
+  agent {
+    dockerfile {
+      filename 'Dockerfile.jenkins-arm'
+      label 'scanner'
+      args '-v /tmp:/tmp'
+    }
+  }
+  stages {
+    stage('Test') {
+      steps {
+        sh 'tox -- --with-scanner'
+        junit 'pytest.xml'
+      }
+    }
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--with-scanner",
+        action="store_true",
+        default=False,
+        help="run tests using an actual scanner"
+    )


### PR DESCRIPTION
- `Jenkinsfile`: Jenkins pipeline with a single stage that runs the tests on the raspberry connected to the scanner.
- `Dockerfile.jenkins-arm`: used in the `Jenkinsfile` to set-up the test environment (install pip and tox). Based on raspberry-sane-git
- `conftest.py`: add a `--with-scanner` option to pytest to enable tests that require a scanner to run