### PR TITLE
Get job from api

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,12 +24,12 @@ pipeline {
     stage('System tests') {
       agent { label 'scanner' }
       steps {
-        withCredentials([
+        withCredentials([[
           $class: 'UsernamePasswordMultiBinding',
           credentialsId: 'scanomatic-staging',
           usernameVariable: 'SCANOMATIC_USERNAME',
-          passwordVariable: 'SCANOMATIC_PASSWORD']]
-        ) {
+          passwordVariable: 'SCANOMATIC_PASSWORD'
+        ]]) {
           sh 'tox -e sys'
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,14 @@ pipeline {
     stage('System tests') {
       agent { label 'scanner' }
       steps {
-        sh 'tox -e sys'
+        withCredentials([
+          $class: 'UsernamePasswordMultiBinding',
+          credentialsId: 'scanomatic-staging',
+          usernameVariable: 'SCANOMATIC_USERNAME',
+          passwordVariable: 'SCANOMATIC_PASSWORD']]
+        ) {
+          sh 'tox -e sys'
+        }
       }
     }
   }

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,3 @@
 apscheduler
 pytz
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,11 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 apscheduler==3.5.0
+certifi==2018.1.18        # via requests
+chardet==3.0.4            # via requests
+idna==2.6                 # via requests
 pytz==2017.3
+requests==2.18.4
 six==1.11.0               # via apscheduler
 tzlocal==1.5.1            # via apscheduler
+urllib3==1.22             # via requests

--- a/scanomaticd/apigateway.py
+++ b/scanomaticd/apigateway.py
@@ -10,12 +10,16 @@ class APIError(Exception):
 
 
 class APIGateway:
-    def __init__(self, apibase):
+    def __init__(self, apibase, scannerid, username, password):
         self.apibase = apibase
+        self.scannerid = scannerid
+        self.username = username
+        self.password = password
 
-    def get_scanner_job(self, scannerid):
+    def get_scanner_job(self):
         response = requests.get(
-            self.apibase + '/scanners/{}/job'.format(scannerid)
+            self.apibase + '/scanners/{}/job'.format(self.scannerid),
+            auth=(self.username, self.password),
         )
         try:
             response.raise_for_status()

--- a/scanomaticd/apigateway.py
+++ b/scanomaticd/apigateway.py
@@ -15,7 +15,7 @@ class APIGateway:
 
     def get_scanner_job(self, scannerid):
         response = requests.get(
-            self.apibase + '/scanners/sc4nn3r/job'
+            self.apibase + '/scanners/{}/job'.format(scannerid)
         )
         try:
             response.raise_for_status()

--- a/scanomaticd/apigateway.py
+++ b/scanomaticd/apigateway.py
@@ -28,7 +28,7 @@ class APIGateway:
         data = response.json()
         if data is None:
             return
-        start = _parse_datetime(data['start'])
+        start = _parse_datetime(data['startTime'])
         duration = timedelta(seconds=data['duration'])
         end = start + duration
         return ScanningJob(

--- a/scanomaticd/apigateway.py
+++ b/scanomaticd/apigateway.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+from scanomaticd.scanning import ScanningJob
+
+
+class APIError(Exception):
+    pass
+
+
+class APIGateway:
+    def __init__(self, apibase):
+        self.apibase = apibase
+
+    def get_scanner_job(self, scannerid):
+        response = requests.get(
+            self.apibase + '/scanners/sc4nn3r/job'
+        )
+        try:
+            response.raise_for_status()
+        except requests.RequestException as error:
+            raise APIError(str(error))
+        data = response.json()
+        if data is None:
+            return
+        start = _parse_datetime(data['start'])
+        duration = timedelta(seconds=data['duration'])
+        end = start + duration
+        return ScanningJob(
+            id=data['identifier'],
+            interval=timedelta(seconds=data['interval']),
+            end_time=end,
+        )
+
+
+def _parse_datetime(s):
+    naive = datetime.strptime(s, '%Y-%m-%dT%H:%M:%SZ')
+    return naive.replace(tzinfo=timezone.utc)

--- a/scanomaticd/communication.py
+++ b/scanomaticd/communication.py
@@ -1,0 +1,9 @@
+class UpdateScanningJobCommand:
+    def __init__(self, scannerid, apigateway):
+        self._scannerid = scannerid
+        self._apigateway = apigateway
+
+    def __call__(self, daemon, currentjob):
+        newjob = self._apigateway.get_scanner_job(self._scannerid)
+        if newjob != currentjob:
+            daemon.set_scanjob(newjob)

--- a/scanomaticd/communication.py
+++ b/scanomaticd/communication.py
@@ -1,9 +1,16 @@
+import logging
+
+
+LOG = logging.getLogger(__name__)
+
+
 class UpdateScanningJobCommand:
-    def __init__(self, scannerid, apigateway):
-        self._scannerid = scannerid
+    def __init__(self, apigateway):
         self._apigateway = apigateway
 
-    def __call__(self, daemon, currentjob):
-        newjob = self._apigateway.get_scanner_job(self._scannerid)
+    def __call__(self, daemon):
+        currentjob = daemon.get_scanning_job()
+        newjob = self._apigateway.get_scanner_job()
         if newjob != currentjob:
-            daemon.set_scanjob(newjob)
+            LOG.info('New job: {}'.format(newjob))
+            daemon.set_scanning_job(newjob)

--- a/scanomaticd/daemon.py
+++ b/scanomaticd/daemon.py
@@ -1,19 +1,33 @@
+from datetime import datetime
+
 from apscheduler.schedulers.blocking import BlockingScheduler
 
 
 class ScanDaemon:
+    JOBID_SCANNING = 'scanning'
+
     def __init__(self, scanningjob, scancommand, scheduler=BlockingScheduler):
         self._scheduler = scheduler()
         self._scancommand = scancommand
-        self._scheduler.add_job(
-            scancommand.execute,
-            'interval',
-            seconds=scanningjob.interval.total_seconds(),
-            end_date=scanningjob.end_time,
-        )
+
+    def set_scanning_job(self, job):
+        if job is None:
+            self._scheduler.remove_job(self.JOBID_SCANNING)
+        else:
+            self._scheduler.add_job(
+                self._scancommand,
+                args=(job,),
+                trigger='interval',
+                coalesce=True,
+                id=self.JOBID_SCANNING,
+                max_instances=1,
+                next_run_time=datetime.now(),
+                replace_existing=True,
+                end_date=job.end_time,
+                seconds=job.interval.total_seconds(),
+            )
 
     def start(self):
-        self._scancommand.execute()
         self._scheduler.start()
 
     def stop(self):

--- a/scanomaticd/daemon.py
+++ b/scanomaticd/daemon.py
@@ -5,10 +5,25 @@ from apscheduler.schedulers.blocking import BlockingScheduler
 
 class ScanDaemon:
     JOBID_SCANNING = 'scanning'
+    JOBID_UPDATESCANNINGJOB = 'update-scanning-job'
+    INTERVAL_UPDATESCANNINGJOB = 60
 
-    def __init__(self, scanningjob, scancommand, scheduler=BlockingScheduler):
+    def __init__(
+        self, updatecommand, scancommand, scheduler=BlockingScheduler
+    ):
         self._scheduler = scheduler()
         self._scancommand = scancommand
+        self._job = None
+        self._scheduler.add_job(
+            updatecommand,
+            args=(self, self._job),
+            trigger='interval',
+            coalesce=True,
+            id=self.JOBID_UPDATESCANNINGJOB,
+            max_instances=1,
+            next_run_time=datetime.now(),
+            seconds=self.INTERVAL_UPDATESCANNINGJOB,
+        )
 
     def set_scanning_job(self, job):
         if job is None:

--- a/scanomaticd/daemon.py
+++ b/scanomaticd/daemon.py
@@ -16,7 +16,7 @@ class ScanDaemon:
         self._job = None
         self._scheduler.add_job(
             updatecommand,
-            args=(self, self._job),
+            args=(self,),
             trigger='interval',
             coalesce=True,
             id=self.JOBID_UPDATESCANNINGJOB,
@@ -41,6 +41,10 @@ class ScanDaemon:
                 end_date=job.end_time,
                 seconds=job.interval.total_seconds(),
             )
+        self._job = job
+
+    def get_scanning_job(self):
+        return self._job
 
     def start(self):
         self._scheduler.start()

--- a/scanomaticd/main.py
+++ b/scanomaticd/main.py
@@ -27,9 +27,13 @@ if __name__ == '__main__':
         LOG.critical("Can't initialise scanner controller: %s", str(error))
         exit(1)
     store = ScanStore('/var/scanomaticd/scans')
-    apigateway = APIGateway(os.environ['SCANOMATICD_APIURL'])
-    scannerid = os.environ['SCANOMATICD_SCANNERID']
+    apigateway = APIGateway(
+        os.environ['SCANOMATICD_APIROOT'],
+        os.environ['SCANOMATICD_SCANNERID'],
+        os.environ['SCANOMATICD_APIUSERNAME'],
+        os.environ['SCANOMATICD_APIPASSWORD'],
+    )
     scan_command = ScanCommand(scanner, store)
-    update_command = UpdateScanningJobCommand(scannerid, apigateway)
+    update_command = UpdateScanningJobCommand(apigateway)
     daemon = ScanDaemon(update_command, scan_command)
     daemon.start()

--- a/scanomaticd/main.py
+++ b/scanomaticd/main.py
@@ -1,6 +1,9 @@
 from datetime import datetime, timedelta
 import logging
+import os
 
+from .apigateway import APIGateway
+from .communication import UpdateScanningJobCommand
 from .daemon import ScanDaemon
 from .scannercontroller import ScanimageScannerController, ScannerError
 from .scanning import ScanCommand, ScanningJob
@@ -24,6 +27,9 @@ if __name__ == '__main__':
         LOG.critical("Can't initialise scanner controller: %s", str(error))
         exit(1)
     store = ScanStore('/var/scanomaticd/scans')
-    command = ScanCommand(job, scanner, store)
-    daemon = ScanDaemon(job, command)
+    apigateway = APIGateway(os.environ['SCANOMATICD_APIURL'])
+    scannerid = os.environ['SCANOMATICD_SCANNERID']
+    scan_command = ScanCommand(scanner, store)
+    update_command = UpdateScanningJobCommand(scannerid, apigateway)
+    daemon = ScanDaemon(update_command, scan_command)
     daemon.start()

--- a/scanomaticd/scanning.py
+++ b/scanomaticd/scanning.py
@@ -11,18 +11,17 @@ Scan = namedtuple('Scan', [
 
 
 class ScanCommand:
-    def __init__(self, job, scanner, scanstore):
-        self._job = job
+    def __init__(self, scanner, scanstore):
         self._scanner = scanner
         self._scanstore = scanstore
 
-    def execute(self):
+    def __call__(self, job):
         start_time = datetime.now()
         data = self._scanner.scan()
         end_time = datetime.now()
         scan = Scan(
             data=data,
-            job_id=self._job.id,
+            job_id=job.id,
             start_time=start_time,
             end_time=end_time,
             digest='sha256:{}'.format(sha256(data).hexdigest()),

--- a/system-tests/test_scanomaticd.py
+++ b/system-tests/test_scanomaticd.py
@@ -31,7 +31,7 @@ def scanning_job(scannerid):
     )
     print(response.json())
     response.raise_for_status()
-    jobid = response.json()['jobId']
+    jobid = response.json()['identifier']
     requests.post(
         APIROOT + '/scan-jobs/{}/start'.format(jobid),
         auth=(USERNAME, PASSWORD),

--- a/system-tests/test_scanomaticd.py
+++ b/system-tests/test_scanomaticd.py
@@ -32,9 +32,10 @@ def scanning_job(scannerid):
     print(response.json())
     response.raise_for_status()
     jobid = response.json()['jobId']
-    (requests
-        .post(APIROOT + '/scan-jobs/{}/start'.format(jobid))
-        .raise_for_status())
+    requests.post(
+        APIROOT + '/scan-jobs/{}/start'.format(jobid),
+        auth=(USERNAME, PASSWORD),
+    ).raise_for_status()
 
 
 @pytest.fixture(autouse=True)

--- a/system-tests/test_scanomaticd.py
+++ b/system-tests/test_scanomaticd.py
@@ -29,7 +29,6 @@ def scanning_job(scannerid):
         },
         auth=(USERNAME, PASSWORD),
     )
-    print(response.json())
     response.raise_for_status()
     jobid = response.json()['identifier']
     requests.post(

--- a/system-tests/test_scanomaticd.py
+++ b/system-tests/test_scanomaticd.py
@@ -10,7 +10,6 @@ import requests
 
 SCANDURATION = timedelta(minutes=3)
 APIROOT = 'https://som.molflow.com/api'
-APIROOT = 'http://192.168.74.130:5050/api'
 USERNAME = os.environ['SCANOMATIC_USERNAME']
 PASSWORD = os.environ['SCANOMATIC_PASSWORD']
 

--- a/system-tests/test_scanomaticd.py
+++ b/system-tests/test_scanomaticd.py
@@ -1,32 +1,68 @@
 from datetime import datetime, timedelta
 from glob import glob
 import time
+import uuid
+import os
 
 import docker
 import pytest
+import requests
 
 SCANDURATION = timedelta(minutes=3)
+APIROOT = 'https://som.molflow.com/api'
+APIROOT = 'http://192.168.74.130:5050/api'
+USERNAME = os.environ['SCANOMATIC_USERNAME']
+PASSWORD = os.environ['SCANOMATIC_PASSWORD']
+
+
+@pytest.fixture
+def scannerid():
+    return '9a8486a6f9cb11e7ac660050b68338ac'
 
 
 @pytest.fixture(autouse=True)
-def scanomaticd(tmpdir):
+def scanning_job(scannerid):
+    response = requests.post(
+        APIROOT + '/scan-jobs',
+        json={
+            'name': uuid.uuid1().hex, 'interval': 300, 'duration': 660,
+            'scannerId': scannerid,
+        },
+        auth=(USERNAME, PASSWORD),
+    )
+    print(response.json())
+    response.raise_for_status()
+    jobid = response.json()['jobId']
+    (requests
+        .post(APIROOT + '/scan-jobs/{}/start'.format(jobid))
+        .raise_for_status())
+
+
+@pytest.fixture(autouse=True)
+def scanomaticd(tmpdir, scannerid):
     dockerclient = docker.from_env()
     container = dockerclient.containers.run(
         'scanomaticd:latest',
         detach=True,
+        environment={
+            'SCANOMATICD_APIROOT': APIROOT,
+            'SCANOMATICD_APIUSERNAME': USERNAME,
+            'SCANOMATICD_APIPASSWORD': PASSWORD,
+            'SCANOMATICD_SCANNERID': scannerid,
+        },
         privileged=True,
         volumes={
             tmpdir: {'bind': '/var/scanomaticd', 'mode': 'rw'},
             '/dev/bus/usb': {'bind': '/dev/bus/usb', 'mode': 'rw'},
         },
     )
-    yield
+    yield container
     container.stop()
     print(container.logs().decode('utf-8'))
     container.remove()
 
 
-def test(tmpdir):
+def test(tmpdir, scanomaticd):
     nbscans = 3
     interval = timedelta(minutes=5)
     begin = datetime.now()
@@ -34,6 +70,7 @@ def test(tmpdir):
     while datetime.now() - begin < (nbscans + 1) * interval:
         if len(glob(str(tmpdir.join('scans', '*.tiff')))) > len(scantimes):
             scantimes.append(datetime.now())
+        assert scanomaticd.status in {'created', 'running'}
         time.sleep(1)
     assert len(scantimes) == nbscans
     assert scantimes[0] - begin < SCANDURATION

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,20 @@ def pytest_addoption(parser):
         default=False,
         help="run tests using an actual scanner"
     )
+    parser.addoption(
+        "--skip-slow",
+        action="store_true",
+        default=False,
+        help="skip tests marked as slow"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--skip-slow"):
+        skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
 
 
 @pytest.fixture

--- a/tests/integration/test_scannercontroller.py
+++ b/tests/integration/test_scannercontroller.py
@@ -70,6 +70,7 @@ class TestScanimageScannerController:
         with pytest.raises(ScannerError, match='bla'):
             ScanimageScannerController()
 
+    @pytest.mark.slow
     @pytest.mark.usefixtures('usbscanner')
     def test_scan_output(self):
         scanner = ScanimageScannerController()

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+
+import pytest
+import responses
+
+from scanomaticd.apigateway import APIGateway, APIError
+from scanomaticd.scanning import ScanningJob
+
+
+@pytest.fixture
+def apigateway():
+    return APIGateway('http://example.com/api')
+
+
+class TestGetScannerJob:
+    SCANNERID = 'sc4nn3r'
+    URI = 'http://example.com/api/scanners/{}/job'.format(SCANNERID)
+
+    @responses.activate
+    def test_with_job(self, apigateway):
+        responses.add(
+            responses.GET, self.URI, json={
+                'identifier': 'j0b',
+                'start': '1985-10-26T01:20:00Z',
+                'duration': 240,
+                'interval': 60,
+            },
+        )
+        job = apigateway.get_scanner_job(self.SCANNERID)
+        assert job == ScanningJob(
+            id='j0b',
+            interval=timedelta(minutes=1),
+            end_time=datetime(1985, 10, 26, 1, 24, tzinfo=timezone.utc),
+        )
+
+    @responses.activate
+    def test_with_no_job(self, apigateway):
+        responses.add(
+            responses.GET, self.URI, body='null',
+        )
+        job = apigateway.get_scanner_job(self.SCANNERID)
+        assert job is None
+
+    @responses.activate
+    def test_with_error(self, apigateway):
+        responses.add(
+            responses.GET,
+            self.URI,
+            status=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
+        with pytest.raises(APIError, match='Internal Server Error'):
+            apigateway.get_scanner_job(self.SCANNERID)

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -44,7 +44,7 @@ class TestGetScannerJob:
         responses.add(
             responses.GET, self.URI, json={
                 'identifier': 'j0b',
-                'start': '1985-10-26T01:20:00Z',
+                'startTime': '1985-10-26T01:20:00Z',
                 'duration': 240,
                 'interval': 60,
             },

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -1,3 +1,4 @@
+from base64 import b64encode
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
@@ -8,17 +9,38 @@ from scanomaticd.apigateway import APIGateway, APIError
 from scanomaticd.scanning import ScanningJob
 
 
+SCANNERID = 'sc4nn3r'
+
+
 @pytest.fixture
 def apigateway():
-    return APIGateway('http://example.com/api')
+    return APIGateway(
+        'http://example.com/api',
+        SCANNERID,
+        'myuser',
+        'mypassword'
+    )
+
+
+def assert_authorized(request):
+    assert 'Authorization' in request.headers
+    assert (
+        request.headers['Authorization']
+        == 'Basic {}'.format(b64encode(b'myuser:mypassword').decode('ascii'))
+    )
 
 
 class TestGetScannerJob:
-    SCANNERID = 'sc4nn3r'
     URI = 'http://example.com/api/scanners/{}/job'.format(SCANNERID)
 
     @responses.activate
-    def test_with_job(self, apigateway):
+    def test_authorization(self, apigateway):
+        responses.add(responses.GET, self.URI, body='null')
+        apigateway.get_scanner_job()
+        assert_authorized(responses.calls[0].request)
+
+    @responses.activate
+    def test_return_job(self, apigateway):
         responses.add(
             responses.GET, self.URI, json={
                 'identifier': 'j0b',
@@ -27,7 +49,7 @@ class TestGetScannerJob:
                 'interval': 60,
             },
         )
-        job = apigateway.get_scanner_job(self.SCANNERID)
+        job = apigateway.get_scanner_job()
         assert job == ScanningJob(
             id='j0b',
             interval=timedelta(minutes=1),
@@ -35,11 +57,11 @@ class TestGetScannerJob:
         )
 
     @responses.activate
-    def test_with_no_job(self, apigateway):
+    def test_return_none_if_no_job(self, apigateway):
         responses.add(
             responses.GET, self.URI, body='null',
         )
-        job = apigateway.get_scanner_job(self.SCANNERID)
+        job = apigateway.get_scanner_job()
         assert job is None
 
     @responses.activate
@@ -50,4 +72,4 @@ class TestGetScannerJob:
             status=HTTPStatus.INTERNAL_SERVER_ERROR,
         )
         with pytest.raises(APIError, match='Internal Server Error'):
-            apigateway.get_scanner_job(self.SCANNERID)
+            apigateway.get_scanner_job()

--- a/tests/unit/test_communication.py
+++ b/tests/unit/test_communication.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from scanomaticd.communication import UpdateScanningJobCommand
+
+
+class TestUpdateScanningJobCommand:
+    @pytest.fixture
+    def job(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def command(self, job):
+        apigateway = MagicMock()
+        apigateway.get_scanner_job.return_value = job
+        return UpdateScanningJobCommand('sc4nn3r', apigateway)
+
+    def test_it_sets_scanjob(self, command, job):
+        daemon = MagicMock()
+        command(daemon, None)
+        daemon.set_scanjob.assert_called_with(job)
+
+    def test_doesnt_set_scanjob_if_not_changed(self, command, job):
+        daemon = MagicMock()
+        command(daemon, job)
+        daemon.set_scanjob.assert_not_called()

--- a/tests/unit/test_communication.py
+++ b/tests/unit/test_communication.py
@@ -14,14 +14,16 @@ class TestUpdateScanningJobCommand:
     def command(self, job):
         apigateway = MagicMock()
         apigateway.get_scanner_job.return_value = job
-        return UpdateScanningJobCommand('sc4nn3r', apigateway)
+        return UpdateScanningJobCommand(apigateway)
 
     def test_it_sets_scanjob(self, command, job):
         daemon = MagicMock()
-        command(daemon, None)
-        daemon.set_scanjob.assert_called_with(job)
+        daemon.get_scanning_job.return_value = None
+        command(daemon)
+        daemon.set_scanning_job.assert_called_with(job)
 
     def test_doesnt_set_scanjob_if_not_changed(self, command, job):
         daemon = MagicMock()
-        command(daemon, job)
-        daemon.set_scanjob.assert_not_called()
+        daemon.get_scanning_job.return_value = job
+        command(daemon)
+        daemon.set_scanning_job.assert_not_called()

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -49,8 +49,12 @@ def job():
     )
 
 
-@pytest.mark.slow
 class TestSetScanningJob:
+    def test_remember_set_job(self, daemon, job):
+        daemon.set_scanning_job(job)
+        assert daemon.get_scanning_job() == job
+
+    @pytest.mark.slow
     def test_complete_scanning_job(self, daemon, job, fakescancommand):
         daemon.set_scanning_job(job)
         sleep(7)
@@ -60,6 +64,7 @@ class TestSetScanningJob:
             (4, call(job)),
         ]
 
+    @pytest.mark.slow
     def test_replace_existing_job(self, daemon, job, fakescancommand):
         daemon.set_scanning_job(job)
         sleep(1)
@@ -76,6 +81,7 @@ class TestSetScanningJob:
             (5, call(job2)),
         ]
 
+    @pytest.mark.slow
     def test_cancel_existing_job(self, daemon, job, fakescancommand):
         daemon.set_scanning_job(job)
         sleep(1)
@@ -91,7 +97,7 @@ class TestUpdateCommand:
     def test_run_every_minutes(self, daemon, fakeupdatecommand):
         sleep(120)
         assert fakeupdatecommand.calls == [
-            (0, call(daemon, None)),
-            (60, call(daemon, None)),
-            (120, call(daemon, None)),
+            (0, call(daemon)),
+            (60, call(daemon)),
+            (120, call(daemon)),
         ]

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -74,7 +74,7 @@ class TestSetScanningJob:
             end_time=datetime.now() + timedelta(seconds=5),
         )
         daemon.set_scanning_job(job2)
-        sleep(4)
+        sleep(5)
         assert fakescancommand.calls == [
             (0, call(job)),
             (1, call(job2)),

--- a/tests/unit/test_scanning.py
+++ b/tests/unit/test_scanning.py
@@ -33,8 +33,8 @@ def test_scancommand(scanningjob):
     scanstore = MagicMock()
     with freeze_time(now) as faketime:
         scanner = FakeScanner(fakedata, faketime)
-        scancommand = ScanCommand(scanningjob, scanner, scanstore)
-        scancommand.execute()
+        scancommand = ScanCommand(scanner, scanstore)
+        scancommand(scanningjob)
     scanstore.put.assert_called_with(
         Scan(
             data=fakedata,

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,6 @@ basepython=python3
 deps =
     pytest
     docker
+    requests
 commands = pytest {posargs} system-tests/
+passenv = SCANOMATIC_USERNAME SCANOMATIC_PASSWORD

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pillow
     pytest
     pytest-cov
+    responses
 commands =
     pytest \
         --cov scanomaticd --cov-report xml --cov-branch \


### PR DESCRIPTION
- Refactor the daemon class to set the scanning job dynamically
- Add an `APIGateway` class to communicate with SoM API
- Add a new scheduled job to update the scanning job every minute

### Testing

This also add a `--skip-slow` flag to the test suite that skips tests marked as slow and mark the timing tests as slow.

The original system test was assuming that the daemon would start
scanning by itself.  Now, we need set-up a job on the server and pass
the proper credentials to the daemon for it to get the scanning
instruction.  The rest is the same (wait for the scanning to finish and
check the times at which the images appeared...)

I decided to experiment a bit with testing in production environment
("staging" actually but the idea is the same): instead of running an
isolated copy of scannomatic to run the tests, I use the existing
staging environement.  There are a few advantages:
- simpler and faster test setup
- tests are done in real condidions (e.g. with password authentication)
- tests are run on a Pi, which can't run scannomatic easily

There are also a few potential problems:
- there's only one scanner, which means there can't be concurrent test
  runs. This will be fixed once we can "register" scanners in some way
- there's a small chance that the test fails because scanomatic is
  redeployed.  If this is a problem, we can tell jenkins to coordinate
  job correctly in order to avoid it.