### PR TITLE
Scannerkeepalive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 .cache
 nosetests.xml
 pytest.xml
+.pytest_cache
 coverage.xml
 *.cover
 .hypothesis/

--- a/scanomaticd/__main__.py
+++ b/scanomaticd/__main__.py
@@ -32,7 +32,7 @@ apigateway = APIGateway(
 )
 scan_command = ScanCommand(scanner, store)
 update_command = UpdateScanningJobCommand(apigateway)
-heartbeat_command = HeartbeatCommand(apigateway, store)
+heartbeat_command = HeartbeatCommand(apigateway, store, scanner)
 upload_command = UploadCommand(apigateway, store)
 daemon = ScanDaemon(
     update_command, scan_command, heartbeat_command, upload_command,

--- a/scanomaticd/apigateway.py
+++ b/scanomaticd/apigateway.py
@@ -43,8 +43,12 @@ class APIGateway:
         )
 
     def update_status(
-        self, job=None, next_scheduled_scan=None, images_to_send=None,
+        self,
+        job=None,
+        next_scheduled_scan=None,
+        images_to_send=None,
         start_time=None,
+        devices=None,
     ):
         url = "{apibase}/scanners/{scannerid}/status".format(
             apibase=self.apibase, scannerid=self.scannerid)
@@ -62,6 +66,7 @@ class APIGateway:
                 "nextScheduledScan": next_scheduled_scan,
                 "imagesToSend": images_to_send,
                 "startTime": start_time,
+                "devices": devices,
             },
         )
         try:

--- a/scanomaticd/heartbeat.py
+++ b/scanomaticd/heartbeat.py
@@ -8,9 +8,10 @@ LOG = logging.getLogger(__name__)
 
 class HeartbeatCommand:
 
-    def __init__(self, apigateway, store):
+    def __init__(self, apigateway, store, scanner):
         self._apigateway = apigateway
         self._store = store
+        self._scannercontroller = scanner
 
     def __call__(self, daemon):
         LOG.info('Reporting scanner status')
@@ -21,6 +22,7 @@ class HeartbeatCommand:
                 next_scheduled_scan=daemon.get_next_scheduled_scan(),
                 images_to_send=len(self._store),
                 start_time=daemon.get_start_time(),
+                devices=self._scannercontroller.get_devices(),
             )
         except APIError as error:
             LOG.warning(

--- a/scanomaticd/scannercontroller.py
+++ b/scanomaticd/scannercontroller.py
@@ -24,7 +24,7 @@ class ScannerError(Exception):
 
 class ScanimageScannerController:
     def __init__(self):
-        devices = self._get_devices()
+        devices = self.get_devices()
         if len(devices) == 1:
             self.device_name = devices[0]
         elif len(devices) > 1:
@@ -38,7 +38,7 @@ class ScanimageScannerController:
     def scan(self):
         return self._run_scanimage('-d', self.device_name, *SCANIMAGE_OPTS)
 
-    def _get_devices(self):
+    def get_devices(self):
         stdout = self._run_scanimage('-f', '%d%n')
         return [dev for dev in stdout.decode('ascii').split()]
 

--- a/tests/unit/test_heartbeat.py
+++ b/tests/unit/test_heartbeat.py
@@ -24,9 +24,15 @@ class TestScannerHeartbeat:
     def store(self):
         return ['Image 1', 'Image 55']
 
-    def test_heartbeat_good_response(self, daemon, apigateway, store):
+    @pytest.fixture
+    def scanner(self):
+        scanner = MagicMock()
+        scanner.get_devices.return_value = ['epson']
+        return scanner
+
+    def test_heartbeat_good_response(self, daemon, apigateway, store, scanner):
         now = datetime.now(tz=timezone.utc)
-        heartbeat = HeartbeatCommand(apigateway, store)
+        heartbeat = HeartbeatCommand(apigateway, store, scanner)
         daemon.get_start_time.return_value = now
         heartbeat(daemon)
         apigateway.update_status.assert_called_once_with(
@@ -34,49 +40,52 @@ class TestScannerHeartbeat:
             next_scheduled_scan=None,
             images_to_send=2,
             start_time=now,
+            devices=['epson'],
         )
 
     def test_heartbeat_bad_response_doesnt_raise(
-        self, daemon, apigateway, store,
-    ):
+            self, daemon, apigateway, store, scanner):
         apigateway.update_status.side_effect = APIError("")
-        heartbeat = HeartbeatCommand(apigateway, store)
+        heartbeat = HeartbeatCommand(apigateway, store, scanner)
         heartbeat(daemon)
 
-    def test_heartbeat_with_scheduled_scan(self, daemon, apigateway, store):
+    def test_heartbeat_with_scheduled_scan(
+            self, daemon, apigateway, store, scanner):
         now = datetime.now(tz=timezone.utc)
         scheduled = now + timedelta(minutes=20)
         daemon.get_next_scheduled_scan.return_value = scheduled
         daemon.get_start_time.return_value = now
-        heartbeat = HeartbeatCommand(apigateway, store)
+        heartbeat = HeartbeatCommand(apigateway, store, scanner)
         heartbeat(daemon)
         apigateway.update_status.assert_called_once_with(
             job=None,
             next_scheduled_scan=scheduled,
             images_to_send=2,
             start_time=now,
+            devices=['epson'],
         )
 
-    def test_heartbeat_with_job(self, daemon, apigateway, scanningjob, store):
+    def test_heartbeat_with_job(
+            self, daemon, apigateway, scanningjob, store, scanner):
         daemon.get_scanning_job.return_value = scanningjob
         now = datetime.now(tz=timezone.utc)
         daemon.get_start_time.return_value = now
-        heartbeat = HeartbeatCommand(apigateway, store)
+        heartbeat = HeartbeatCommand(apigateway, store, scanner)
         heartbeat(daemon)
         apigateway.update_status.assert_called_once_with(
             job=scanningjob.id,
             next_scheduled_scan=None,
             images_to_send=2,
             start_time=now,
+            devices=['epson'],
         )
 
     def test_hearbeat_with_no_images_to_send(
-        self, daemon, apigateway, scanningjob, store
-    ):
+            self, daemon, apigateway, scanningjob, store, scanner):
         daemon.get_scanning_job.return_value = scanningjob
         now = datetime.now(tz=timezone.utc)
         daemon.get_start_time.return_value = now
-        heartbeat = HeartbeatCommand(apigateway, store)
+        heartbeat = HeartbeatCommand(apigateway, store, scanner)
         store.clear()
         heartbeat(daemon)
         apigateway.update_status.assert_called_once_with(
@@ -84,4 +93,5 @@ class TestScannerHeartbeat:
             next_scheduled_scan=None,
             images_to_send=0,
             start_time=now,
+            devices=['epson'],
         )


### PR DESCRIPTION
Using get_devices from scannercontroller in heartbeat to keep scanner alive.
This sends list of devices to API.